### PR TITLE
Modify add/remove dependency handling

### DIFF
--- a/src/main/java/info/bluespot/plugins/AddDependency.java
+++ b/src/main/java/info/bluespot/plugins/AddDependency.java
@@ -19,9 +19,8 @@ package info.bluespot.plugins;
  * under the License.
  */
 
-import java.io.IOException;
-
 import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.model.Model;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -30,133 +29,164 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static info.bluespot.plugins.utils.ArtifactUtils.matches;
+
 /**
  * Adds a dependency to a POM file.
- * <p>
- * The <code>artifactId</code> and the <code>groupId</code> of the dependency are needed parameters.
- * </p>
- * 
+ *
+ * <p>The <code>artifactId</code> and the <code>groupId</code> of the dependency are needed
+ * parameters.
+ *
  * @since 1.0.0
  */
-@Mojo( name = "add-dependency", requiresProject = true, inheritByDefault = false )
-public class AddDependency
-    extends AbstractMojo
-{
-    // PARAMETERS ............................................................
+@Mojo(name = "add-dependency", requiresProject = true, inheritByDefault = false)
+public class AddDependency extends AbstractMojo {
+  // PARAMETERS ............................................................
 
-    /**
-     * Dependency's <code>ArtifactId</code>.
-     */
-    @Parameter( property = "artifactId", required = true, readonly = true )
-    private String artifactId;
+  /** Dependency's <code>ArtifactId</code>. */
+  @Parameter(property = "artifactId", required = true, readonly = true)
+  private String artifactId;
 
-    /**
-     * Dependency's <code>GroupId</code>.
-     */
-    @Parameter( property = "groupId", required = true, readonly = true )
-    private String groupId;
+  /** Dependency's <code>GroupId</code>. */
+  @Parameter(property = "groupId", required = true, readonly = true)
+  private String groupId;
 
-    /**
-     * Dependency's version (optional).
-     */
-    @Parameter( property = "version", required = false, readonly = true )
-    private String version;
+  /** Dependency's version (optional). */
+  @Parameter(property = "version", required = false, readonly = true)
+  private String version;
 
-    /**
-     * Dependency's <code>systemPath</code>.
-     */
-    @Parameter( property = "systemPath", required = false, readonly = true )
-    private String systemPath;
+  /** Dependency's <code>systemPath</code>. */
+  @Parameter(property = "systemPath", required = false, readonly = true)
+  private String systemPath;
 
-    /**
-     * Dependency's <code>type</code>.
-     */
-    @Parameter( property = "type", required = false, readonly = true )
-    private String type;
+  /** Dependency's <code>type</code>. */
+  @Parameter(property = "type", required = false, readonly = true)
+  private String type;
 
-    /**
-     * Dependency's <code>scope</code>.
-     */
-    @Parameter( property = "scope", required = false, readonly = true )
-    private String scope;
+  /** Dependency's <code>scope</code>. */
+  @Parameter(property = "scope", required = false, readonly = true)
+  private String scope;
 
-    /**
-     * Dependency's <code>optional</code> field.
-     */
-    @Parameter( property = "optional", required = false, readonly = true, defaultValue = "false" )
-    private Boolean optional;
+  /** Dependency's <code>optional</code> field. */
+  @Parameter(property = "optional", required = false, readonly = true, defaultValue = "false")
+  private Boolean optional;
 
-    /**
-     * Keeps a copy of the current POM file before modifying it.
-     */
-    @Parameter( property = "pomBackup", required = false, readonly = true )
-    private String pomBackup;
+  /** Keeps a copy of the current POM file before modifying it. */
+  @Parameter(property = "pomBackup", required = false, readonly = true)
+  private String pomBackup;
 
-    /**
-     * Specifies a POM file to modify.
-     */
-    @Parameter( property = "pomFile", required = false, readonly = true, defaultValue = "pom.xml" )
-    private String pomFile;
+  /** Specifies a POM file to modify. */
+  @Parameter(property = "pomFile", required = false, readonly = true, defaultValue = "pom.xml")
+  private String pomFile;
 
-    // METHODS ...............................................................
+  /** Dependency <code>ModifyDependencyManagement</code>. */
+  @Parameter(property = "modifyDependencyManagement", required = false)
+  private Boolean modifyDependencyManagement;
 
-    /**
-     * Main goal method.
-     */
-    @Override
-    public void execute()
-        throws MojoExecutionException, MojoFailureException
-    {
-        getLog().info( "Adding the dependency " + groupId + ":" + artifactId );
+  // METHODS ...............................................................
 
-        // Load the model
-        Model model;
-        try
-        {
-            model = POMUtils.loadModel( pomFile );
-        }
-        catch ( IOException | XmlPullParserException e )
-        {
-            throw new MojoExecutionException( "Error while loading the Maven model.", e );
-        }
+  /** Main goal method. */
+  @Override
+  public void execute() throws MojoExecutionException, MojoFailureException {
+    getLog().info("Adding the dependency " + groupId + ":" + artifactId);
 
-        // Creating a dependency object
-        Dependency dependency = new Dependency();
-
-        dependency.setArtifactId( artifactId );
-        dependency.setGroupId( groupId );
-        if ( version != null )
-        {
-            dependency.setVersion( version );
-        }
-        if ( systemPath != null )
-        {
-            dependency.setSystemPath( systemPath );
-        }
-        if ( type != null )
-        {
-            dependency.setType( type );
-        }
-        if ( scope != null )
-        {
-            dependency.setScope( scope );
-        }
-        if ( optional )
-        {
-            dependency.setOptional( true );
-        }
-
-        // Add the dependency to the model
-        model.addDependency( dependency );
-
-        // Save the model
-        try
-        {
-            POMUtils.saveModel( model, pomFile, pomBackup );
-        }
-        catch ( IOException e )
-        {
-            throw new MojoExecutionException( "I/O error while writing the Maven model.", e );
-        }
+    // Load the model
+    Model model;
+    try {
+      model = POMUtils.loadModel(pomFile);
+    } catch (IOException | XmlPullParserException e) {
+      throw new MojoExecutionException("Error while loading the Maven model.", e);
     }
+
+    // Creating a dependency object
+    Dependency dependency = new Dependency();
+
+    dependency.setArtifactId(artifactId);
+    dependency.setGroupId(groupId);
+    if (version != null) {
+      dependency.setVersion(version);
+    }
+    if (systemPath != null) {
+      dependency.setSystemPath(systemPath);
+    }
+    if (type != null) {
+      dependency.setType(type);
+    }
+    if (scope != null) {
+      dependency.setScope(scope);
+    }
+    if (optional) {
+      dependency.setOptional(true);
+    }
+
+    model =
+        addDependency(model, dependency, groupId, artifactId, version, modifyDependencyManagement);
+
+    // Save the model
+    try {
+      POMUtils.saveModel(model, pomFile, pomBackup);
+    } catch (IOException e) {
+      throw new MojoExecutionException("I/O error while writing the Maven model.", e);
+    }
+  }
+
+  private Model addDependency(
+      Model model,
+      Dependency dependency,
+      String groupId,
+      String artifactId,
+      String version,
+      Boolean modifyDependencyManagement) {
+    if (modifyDependencyManagement != null) {
+      if (model.getDependencyManagement() != null) {
+
+        DependencyManagement dependencyManagement = model.getDependencyManagement();
+        List<Dependency> newDependencyManagementDependencyList = new ArrayList<>();
+
+        for (Dependency dependencyTemp : dependencyManagement.getDependencies()) {
+          // If a matching dependency is found, remove it; if not, the dependency is added to the
+          // new list.
+          if (matches(dependencyTemp, groupId, artifactId, version)) {
+            getLog().info("Duplicated dependency found in dependency management.");
+            newDependencyManagementDependencyList.remove(dependencyTemp);
+          } else {
+            newDependencyManagementDependencyList.add(dependencyTemp);
+          }
+        }
+
+        getLog().info("Add requesting dependency to dependency management.");
+        newDependencyManagementDependencyList.add(dependency);
+
+        dependencyManagement.setDependencies(newDependencyManagementDependencyList);
+        model.setDependencyManagement(dependencyManagement);
+      } else {
+        DependencyManagement dependencyManagement = new DependencyManagement();
+        dependencyManagement.addDependency(dependency);
+        model.setDependencyManagement(dependencyManagement);
+      }
+    }
+
+    List<Dependency> newDependencyList = new ArrayList<>();
+
+    for (Dependency dependencyTemp : model.getDependencies()) {
+      // If a matching dependency is found, remove it; if not, the dependency is added to the new
+      // list.
+      if (matches(dependencyTemp, groupId, artifactId, version)) {
+        getLog().info("Duplicated dependency found in dependencies.");
+        newDependencyList.remove(dependencyTemp);
+      } else {
+        newDependencyList.add(dependencyTemp);
+      }
+    }
+
+    getLog().info("Add requesting dependency to dependencies.");
+    newDependencyList.add(dependency);
+
+    model.setDependencies(newDependencyList);
+    return model;
+  }
 }

--- a/src/main/java/info/bluespot/plugins/utils/ArtifactUtils.java
+++ b/src/main/java/info/bluespot/plugins/utils/ArtifactUtils.java
@@ -1,0 +1,80 @@
+package info.bluespot.plugins.utils;
+
+import org.apache.maven.model.Dependency;
+
+public class ArtifactUtils {
+
+  /**
+   * Auxiliary method for match a dependency with 'whatever' has been provided (the <code>groupId
+   * </code>, the </code>artifactId</code>, both of them, all the GAV coordinates, etc.).
+   *
+   * @param dependency A dependency object from the POM.
+   * @return 'true' if there's any match.
+   */
+  public static boolean matches(
+      Dependency dependency, String groupId, String artifactId, String version) {
+    // Look for all the matches
+    return (matchesGroupId(dependency, groupId)
+        && matchesArtifactId(dependency, artifactId)
+        && matchesVersion(dependency, version));
+  }
+
+  /**
+   * Auxiliary method for check a <code>GroupId</code> match.
+   *
+   * @param dependency A dependency object from the POM.
+   * @return 'true' if the <code>GroupId</code> matches.
+   */
+  private static boolean matchesGroupId(Dependency dependency, String groupId) {
+    // If the GroupId is not provided, it's OK (the match could be over the ArtifactId or the
+    // version)
+    if (groupId == null) {
+      return (true);
+    }
+
+    if (groupId.equals(dependency.getGroupId())) {
+      return (true);
+    } else {
+      return (false);
+    }
+  }
+
+  /**
+   * Auxiliary method for check a <code>ArtifactId</code> match.
+   *
+   * @param dependency A dependency object from the POM.
+   * @return 'true' if the <code>ArtifactId</code> matches.
+   */
+  private static boolean matchesArtifactId(Dependency dependency, String artifactId) {
+    // If the ArtifactId is not provided, it's OK (the match could be over the GroupId or the
+    // version)
+    if (artifactId == null) {
+      return (true);
+    }
+
+    if (artifactId.equals(dependency.getArtifactId())) {
+      return (true);
+    } else {
+      return (false);
+    }
+  }
+
+  /**
+   * Auxiliary method for check a <code>Version</code> match.
+   *
+   * @param dependency A dependency object from the POM.
+   * @return 'true' if the <code>Version</code> matches.
+   */
+  private static boolean matchesVersion(Dependency dependency, String version) {
+    // If the Version is not provided, it's OK
+    if (version == null) {
+      return (true);
+    }
+
+    if (version.equals(dependency.getVersion())) {
+      return (true);
+    } else {
+      return (false);
+    }
+  }
+}


### PR DESCRIPTION
Provide a flag to add or remove a single dependency to respectively from the dependency management declaration block. Ensure a dependency gets added a single time, only when several runs of the plugin get executed. Reformat touched code.